### PR TITLE
add component helper to shopware env

### DIFF
--- a/@tool/setup-env-for-shopware.js
+++ b/@tool/setup-env-for-shopware.js
@@ -14,4 +14,5 @@ module.exports = (() => {
     require(resolve(join(srcPath, 'src/app/filter/index.js'))).default(); // eslint-disable-line
     require(resolve(join(srcPath, 'src/app/filter/index.js'))).default(); // eslint-disable-line
     require(resolve(join(srcPath, 'src/app/init-pre/state.init.js'))).default(); // eslint-disable-line
+    require(resolve(join(srcPath, 'src/app/init/component-helper.init.js'))).default(); // eslint-disable-line
 })();


### PR DESCRIPTION
It is not possible to use the Component Helper in unit tests. 

This change allows to use the Shopware component helper in all tests to support testing of components with state.