### PR TITLE
NEXT-36699 - enable warnings with disabled compat mode

### DIFF
--- a/@tool/setup-env-for-shopware.js
+++ b/@tool/setup-env-for-shopware.js
@@ -5,12 +5,15 @@ if (!srcPath) {
     throw new Error('"globals.adminPath" is not defined. A file path to a Shopware 6 administration is required');
 }
 
+const disableJestCompatMode = process.env.DISABLE_JEST_COMPAT_MODE === 'true' ?? false;
+
 global.window._features_ = {};
-global.console.warn = () => {};
+
+if (!disableJestCompatMode) {
+    global.console.warn = () => {};
+}
 
 const Shopware = require(resolve(join(srcPath, `src/core/shopware.ts`))).ShopwareInstance;
-
-const disableJestCompatMode = process.env.DISABLE_JEST_COMPAT_MODE === 'true' ?? false;
 
 // Take all keys out of Shopware.compatConfig but set them to true
 const compatConfig = Object.fromEntries(Object.keys(Shopware.compatConfig).map(key => [key, !disableJestCompatMode]));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [v4.3.0] - 2024-06-16
+## [v4.3.1] - 2024-06-13
+
+### Changed
+- Enable the console warnings when Vue compat mode is disabled
+
+## [v4.3.0] - 2024-06-12
 
 ### Added
 - Added the possibiliy to disable the Vue compat mode by setting the environment variable `DISABLE_JEST_COMPAT_MODE` to `true`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shopware-ag/jest-preset-sw6-admin",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shopware-ag/jest-preset-sw6-admin",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.17.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-ag/jest-preset-sw6-admin",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Jest Test preset for Shopware 6 administration unit tests",
   "main": "jest-preset.js",
   "keywords": [


### PR DESCRIPTION
Currently warnings are supressed because the compat mode throw many warnings when using old syntax. But when the compat mode is disabled the warnings should be visible so that it is possible to upgrade the components