### PR TITLE
NEXT-36700 - Replace vuex with pinia

### DIFF
--- a/@tool/setup-env-for-shopware.js
+++ b/@tool/setup-env-for-shopware.js
@@ -23,6 +23,10 @@ const envBefore = process.env.NODE_ENV;
 process.env.NODE_ENV = 'production';
 const configureCompat = require(resolve(join(srcPath, 'node_modules/@vue/compat/dist/vue.cjs.js'))).configureCompat;
 
+// Enable Pinia support
+const vueUse = require(resolve(join(srcPath, 'node_modules/@vue/compat/dist/vue.cjs.js'))).use;
+vueUse(Shopware.Store._rootState);
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call
 configureCompat(compatConfig);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v4.3.2] - 2024-06-17
+
+### Changed
+- Enabled Pinia support in `setup-env-for-shopware.js`
+
 ## [v4.3.1] - 2024-06-13
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-ag/jest-preset-sw6-admin",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Jest Test preset for Shopware 6 administration unit tests",
   "main": "jest-preset.js",
   "keywords": [


### PR DESCRIPTION
We need to globally enable Pinia support. I previously did this in the Admin setup file after env but this is needed for plugins as well.