### PR TITLE
chore: update babel-plugin-shopware-vite-meta-glob to ^0.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "7.28.5",
         "@babel/preset-typescript": "7.28.5",
         "babel-jest": "^27.5.1",
-        "babel-plugin-shopware-vite-meta-glob": "^0.0.4"
+        "babel-plugin-shopware-vite-meta-glob": "^0.0.5"
       },
       "engines": {
         "node": "^20.0.0 || ^21.0.0 || ^22.0.0 || ^23.0.0 || ^24.0.0 || ^25.0.0",
@@ -982,9 +982,9 @@
       }
     },
     "node_modules/babel-plugin-shopware-vite-meta-glob": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-shopware-vite-meta-glob/-/babel-plugin-shopware-vite-meta-glob-0.0.4.tgz",
-      "integrity": "sha512-IxqYybhZIOJ863qjV4TePlOIjh4WSr4jKt9hUjYok8AQbemK1Ft+U7sScfYZTKZiomHT6yKBAR65oahJMQ8l7g==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-shopware-vite-meta-glob/-/babel-plugin-shopware-vite-meta-glob-0.0.5.tgz",
+      "integrity": "sha512-a+yw8Bev1jrvS0EgvmIWpeiUkTj/Nay3zNCxJEjMeUtvSJJC+E26nMLzVx08K7NhZ6QN+ZIqOyRHowrJl1nEow==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.28.4",
@@ -993,7 +993,7 @@
         "glob": "12.0.0"
       },
       "engines": {
-        "node": "^20.0.0 || ^21.0.0 || ^22.0.0 || ^23.0.0 || ^24.0.0",
+        "node": "^20.0.0 || ^21.0.0 || ^22.0.0 || ^23.0.0 || ^24.0.0 || ^25.0.0",
         "npm": ">=10.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/core": "7.28.5",
     "@babel/preset-typescript": "7.28.5",
     "babel-jest": "^27.5.1",
-    "babel-plugin-shopware-vite-meta-glob": "^0.0.4"
+    "babel-plugin-shopware-vite-meta-glob": "^0.0.5"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-ag/jest-preset-sw6-admin",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "description": "Jest Test preset for Shopware 6 administration unit tests",
   "main": "jest-preset.js",
   "keywords": [


### PR DESCRIPTION
## Summary

- Update babel-plugin-shopware-vite-meta-glob from ^0.0.4 to ^0.0.5
- Adds Node 25 support for the plugin

## Test plan

- [ ] Verify the dependency update works correctly